### PR TITLE
Loading CSS files before JS files

### DIFF
--- a/_site/advanced-planning-exercises/index.html
+++ b/_site/advanced-planning-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+    <link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/advanced-search-exercises/index.html
+++ b/_site/advanced-search-exercises/index.html
@@ -17,6 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
+    <link rel="stylesheet" type="text/css" href="/style.css" />
     
 
     <!--[if lt IE 9]>
@@ -27,7 +28,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/agents-exercises/index.html
+++ b/_site/agents-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/bayes-nets-exercises/index.html
+++ b/_site/bayes-nets-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/bayesian-learning-exercises/index.html
+++ b/_site/bayesian-learning-exercises/index.html
@@ -14,7 +14,7 @@
     
     <meta name="author" content="" />
 
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/complex-decisions-exercises/index.html
+++ b/_site/complex-decisions-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/csp-exercises/index.html
+++ b/_site/csp-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/dbn-exercises/index.html
+++ b/_site/dbn-exercises/index.html
@@ -14,7 +14,7 @@
     
     <meta name="author" content="" />
 
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/decision-theory-exercises/index.html
+++ b/_site/decision-theory-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/fol-exercises/index.html
+++ b/_site/fol-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/game-playing-exercises/index.html
+++ b/_site/game-playing-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/ilp-exercises/index.html
+++ b/_site/ilp-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+ <link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+   
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/index.html
+++ b/_site/index.html
@@ -14,7 +14,7 @@
     
     <meta name="author" content="" />
 
-    
+     <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -24,7 +24,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+   
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/intro-exercises/index.html
+++ b/_site/intro-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    <
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/knowledge-logic-exercises/index.html
+++ b/_site/knowledge-logic-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/kr-exercises/index.html
+++ b/_site/kr-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/logical-inference-exercises/index.html
+++ b/_site/logical-inference-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/nlp-communicating-exercises/index.html
+++ b/_site/nlp-communicating-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/nlp-english-exercises/index.html
+++ b/_site/nlp-english-exercises/index.html
@@ -14,7 +14,7 @@
     
     <meta name="author" content="" />
 
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/perception-exercises/index.html
+++ b/_site/perception-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/philosophy-exercises/index.html
+++ b/_site/philosophy-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/planning-exercises/index.html
+++ b/_site/planning-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/probability-exercises/index.html
+++ b/_site/probability-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/reinforcement-learning-exercises/index.html
+++ b/_site/reinforcement-learning-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+    <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/robotics-exercises/index.html
+++ b/_site/robotics-exercises/index.html
@@ -17,7 +17,7 @@
     
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
-    
+     <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+   
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/_site/search-exercises/index.html
+++ b/_site/search-exercises/index.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Main" />
     <meta property="twitter:title" content="Main" />
     
-
+<link rel="stylesheet" type="text/css" href="/style.css" />
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="//aima-exercises.firebaseapp.com/config.js"></script>
 <!--     <script src="//http://www.gstatic.com/firebasejs/5.0.4/firebase-firestore.js"></script>
  -->
-    <link rel="stylesheet" type="text/css" href="/style.css" />
+    
     <link rel="alternate" type="application/rss+xml" title=" - " href="/feed.xml" />
 <!--     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
  -->

--- a/markdown/7-Logical-Agents/README.md
+++ b/markdown/7-Logical-Agents/README.md
@@ -19,7 +19,7 @@
 | 15 | Unanswered | [`Question`](exercises/ex_15/question.md) / [`Answer`](exercises/ex_15/answer.md)|
 | 16 | Unanswered | [`Question`](exercises/ex_16/question.md) / [`Answer`](exercises/ex_16/answer.md)|
 | 17 | Unanswered | [`Question`](exercises/ex_17/question.md) / [`Answer`](exercises/ex_17/answer.md)|
-| 18 | Answered | [`Question`](exercises/ex_18/question.md) / [`Answer`](exercises/ex_18/answer.md)|
+| 18 | Unanswered | [`Question`](exercises/ex_18/question.md) / [`Answer`](exercises/ex_18/answer.md)|
 | 19 | Unanswered | [`Question`](exercises/ex_19/question.md) / [`Answer`](exercises/ex_19/answer.md)|
 | 20 | Unanswered | [`Question`](exercises/ex_20/question.md) / [`Answer`](exercises/ex_20/answer.md)|
 | 21 | Unanswered | [`Question`](exercises/ex_21/question.md) / [`Answer`](exercises/ex_21/answer.md)|

--- a/markdown/7-Logical-Agents/README.md
+++ b/markdown/7-Logical-Agents/README.md
@@ -19,7 +19,7 @@
 | 15 | Unanswered | [`Question`](exercises/ex_15/question.md) / [`Answer`](exercises/ex_15/answer.md)|
 | 16 | Unanswered | [`Question`](exercises/ex_16/question.md) / [`Answer`](exercises/ex_16/answer.md)|
 | 17 | Unanswered | [`Question`](exercises/ex_17/question.md) / [`Answer`](exercises/ex_17/answer.md)|
-| 18 | Unanswered | [`Question`](exercises/ex_18/question.md) / [`Answer`](exercises/ex_18/answer.md)|
+| 18 | Answered | [`Question`](exercises/ex_18/question.md) / [`Answer`](exercises/ex_18/answer.md)|
 | 19 | Unanswered | [`Question`](exercises/ex_19/question.md) / [`Answer`](exercises/ex_19/answer.md)|
 | 20 | Unanswered | [`Question`](exercises/ex_20/question.md) / [`Answer`](exercises/ex_20/answer.md)|
 | 21 | Unanswered | [`Question`](exercises/ex_21/question.md) / [`Answer`](exercises/ex_21/answer.md)|


### PR DESCRIPTION
To ensure CSS files are downloaded in parallel, CSS files should be included before Javascript.
Changed the position of CSS linking statement before script js linking statements in chapter list and all exercises page.  Will change for all the exercises individually if this pull request gets merged. 