### PR TITLE
Make pipe symbol | show up

### DIFF
--- a/markdown/13-Quantifying-Uncertainity/exercises/ex_1/question.md
+++ b/markdown/13-Quantifying-Uncertainity/exercises/ex_1/question.md
@@ -1,3 +1,3 @@
 
 
-Show from first principles that $P(a{{\,|\,}}b\land a) = 1$.
+Show from first principles that $P(a$|$b\land a) = 1$.


### PR DESCRIPTION
I believe this is supposed to be a pipe symbol between a and b, right? Nothing shows up between them on the websitehttps://aimacode.github.io/aima-exercises/probability-exercises/ex_1/